### PR TITLE
Fix build error in Request.Param(): too many arguments to return

### DIFF
--- a/request.go
+++ b/request.go
@@ -11,5 +11,6 @@ type Request struct {
 }
 
 func (r *Request) Param(key string) string {
-	return r.params.Get(key)
+	value, _ := r.params.Get(key)
+	return value
 }


### PR DESCRIPTION
Looks like a breaking change in github.com/karlseguin/params is causing a build error when doing a fresh go get.

> router/request.go:14: too many arguments to return

This commit fixes it without changing the API.
